### PR TITLE
Revert "fix(helm): update chart operator to 5.0.12"

### DIFF
--- a/kubernetes/apps/minio/minio/operator/release.yaml
+++ b/kubernetes/apps/minio/minio/operator/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: operator
-      version: 5.0.12
+      version: 5.0.11
       sourceRef:
         kind: HelmRepository
         name: minio


### PR DESCRIPTION
Reverts otosky/home-ops#981

dunno what's up with this chart at 5.0.12 but it don't work