### PR TITLE
Revert "fix(helm): update chart superset to 0.13.4"

### DIFF
--- a/kubernetes/apps/dev/superset/app/release.yaml
+++ b/kubernetes/apps/dev/superset/app/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: superset
-      version: 0.13.4
+      version: 0.13.1
       sourceRef:
         kind: HelmRepository
         name: superset


### PR DESCRIPTION
Reverts otosky/home-ops#1735

I can't believe this is still an issue