### PR TITLE
feat(home): add vikunja

### DIFF
--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./emqx/ks.yaml
   - ./zigbee/ks.yaml
   - ./home-assistant/ks.yaml
+  - ./vikunja/ks.yaml

--- a/kubernetes/apps/home/vikunja/app/externalsecret.yaml
+++ b/kubernetes/apps/home/vikunja/app/externalsecret.yaml
@@ -20,7 +20,7 @@ spec:
         VIKUNJA_DATABASE_USER: vikunja
         VIKUNJA_DATABASE_PASSWORD: "{{ .POSTGRES_PASSWORD }}"
         VIKUNJA_DATABASE_SSLMODE: disable
-        VIKUNJA_SERVICE_SECRET: "{{ .SERVICE_SECRET }}"
+        VIKUNJA_SERVICE_SECRET: "{{ .VIKUNJA_SECRET }}"
         # Postgres Init
         INIT_POSTGRES_HOST: postgres-rw.database.svc.cluster.local
         INIT_POSTGRES_USER: vikunja

--- a/kubernetes/apps/home/vikunja/app/externalsecret.yaml
+++ b/kubernetes/apps/home/vikunja/app/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vikunja
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: vikunja-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # App
+        VIKUNJA_DATABASE_TYPE: postgres
+        VIKUNJA_DATABASE_HOST: postgres-rw.database.svc.cluster.local
+        VIKUNJA_DATABASE_DATABASE: vikunja
+        VIKUNJA_DATABASE_USER: vikunja
+        VIKUNJA_DATABASE_PASSWORD: "{{ .POSTGRES_PASSWORD }}"
+        VIKUNJA_DATABASE_SSLMODE: disable
+        VIKUNJA_SERVICE_SECRET: "{{ .SERVICE_SECRET }}"
+        # Postgres Init
+        INIT_POSTGRES_HOST: postgres-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: vikunja
+        INIT_POSTGRES_PASS: "{{ .POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_DBNAME: vikunja
+        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: vikunja
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/home/vikunja/app/helmrelease.yaml
+++ b/kubernetes/apps/home/vikunja/app/helmrelease.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vikunja
+spec:
+  interval: 15m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      main:
+        type: deployment
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          01-init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.1.0
+            envFrom:
+              - secretRef:
+                  name: vikunja-secret
+        containers:
+          main:
+            image:
+              repository: docker.io/vikunja/vikunja
+              tag: 2.3.0
+            env:
+              VIKUNJA_SERVICE_PUBLICURL: "https://{{ .Release.Name }}.${SECRET_DOMAIN}"
+              VIKUNJA_SERVICE_TIMEZONE: "America/Los_Angeles"
+              VIKUNJA_SERVICE_ENABLEREGISTRATION: "true"
+              VIKUNJA_SERVICE_ENABLETASKATTACHMENTS: "true"
+            envFrom:
+              - secretRef:
+                  name: vikunja-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v1/info
+                    port: &port 3456
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: "OnRootMismatch"
+            runAsNonRoot: true
+    service:
+      main:
+        ports:
+          http:
+            port: *port
+    route:
+      main:
+        hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: internal
+            namespace: kube-system
+            sectionName: https
+    persistence:
+      files:
+        enabled: true
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        storageClass: longhorn-ssd
+        size: 5Gi
+        globalMounts:
+          - path: /app/vikunja/files

--- a/kubernetes/apps/home/vikunja/app/kustomization.yaml
+++ b/kubernetes/apps/home/vikunja/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/home/vikunja/ks.yaml
+++ b/kubernetes/apps/home/vikunja/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vikunja
+  namespace: &namespace home
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: database
+    - name: onepassword-connect
+      namespace: external-secrets
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 30m
+  path: ./kubernetes/apps/home/vikunja/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 1m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true


### PR DESCRIPTION
## Summary
- add Vikunja under the home namespace with the bjw-s app-template chart
- configure Postgres initialization via ExternalSecret and CloudNativePG
- expose Vikunja through the internal Gateway route

## Verification
- Not run; CI will validate the manifests.

<!-- branch-stack-start -->

<!-- branch-stack-end -->

