### PR TITLE
feat(authentik): manage forgejo oidc with opentofu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@
 kubeconfig
 talosconfig
 
+# Terraform / OpenTofu
+.terraform/
+*.tfstate
+*.tfstate.*
+tfplan
+
 # Misc.
 .private/
 .task/

--- a/kubernetes/apps/dev/forgejo/app/externalsecret.yaml
+++ b/kubernetes/apps/dev/forgejo/app/externalsecret.yaml
@@ -31,3 +31,24 @@ spec:
         key: forgejo
     - extract:
         key: cloudnative-pg
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: forgejo-authentik-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: forgejo-authentik-oidc-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        key: "{{ .AUTHENTIK_CLIENT_ID }}"
+        secret: "{{ .AUTHENTIK_CLIENT_SECRET }}"
+  dataFrom:
+    - extract:
+        key: forgejo

--- a/kubernetes/apps/dev/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/forgejo/app/helmrelease.yaml
@@ -60,6 +60,14 @@ spec:
             secretKeyRef:
               name: forgejo-secret
               key: database-password
+      oauth:
+        - name: authentik
+          provider: openidConnect
+          existingSecret: forgejo-authentik-oidc-secret
+          autoDiscoverUrl: https://auth.${SECRET_DOMAIN}/application/o/forgejo/.well-known/openid-configuration
+          scopes: openid profile email groups
+          groupClaimName: groups
+          adminGroup: forgejo-admins
       metrics:
         enabled: true
         serviceMonitor:
@@ -81,6 +89,11 @@ spec:
           PATH: /data/git/lfs
         mailer:
           ENABLED: false
+        oauth2_client:
+          ENABLE_AUTO_REGISTRATION: true
+          ACCOUNT_LINKING: auto
+          UPDATE_AVATAR: true
+          USERNAME: email
         queue:
           TYPE: level
         repository:
@@ -96,8 +109,11 @@ spec:
           SSH_PORT: 22
           SSH_LISTEN_PORT: 2222
         service:
+          ALLOW_ONLY_EXTERNAL_REGISTRATION: true
           DISABLE_REGISTRATION: true
           DEFAULT_ENABLE_TIMETRACKING: false
+          ENABLE_INTERNAL_SIGNIN: true
+          ENABLE_PASSWORD_SIGNIN_FORM: true
           SHOW_REGISTRATION_BUTTON: false
         service.explore:
           DISABLE_CODE_PAGE: true

--- a/kubernetes/apps/dev/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/forgejo/app/helmrelease.yaml
@@ -110,7 +110,7 @@ spec:
           SSH_LISTEN_PORT: 2222
         service:
           ALLOW_ONLY_EXTERNAL_REGISTRATION: true
-          DISABLE_REGISTRATION: true
+          DISABLE_REGISTRATION: false
           DEFAULT_ENABLE_TIMETRACKING: false
           ENABLE_INTERNAL_SIGNIN: true
           ENABLE_PASSWORD_SIGNIN_FORM: true

--- a/kubernetes/apps/dev/forgejo/ks.yaml
+++ b/kubernetes/apps/dev/forgejo/ks.yaml
@@ -14,6 +14,8 @@ spec:
       namespace: database
     - name: onepassword-connect
       namespace: external-secrets
+    - name: tofu-controller-terraforms
+      namespace: flux-system
   decryption:
     provider: sops
     secretRef:

--- a/kubernetes/apps/flux-system/tofu-controller/ks.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/ks.yaml
@@ -33,4 +33,34 @@ spec:
   targetNamespace: *namespace
   timeout: 5m
   wait: false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tofu-controller-terraforms
+  namespace: &namespace flux-system
+spec:
+  dependsOn:
+    - name: tofu-controller
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: authentik
+      namespace: security
+  healthChecks:
+    - apiVersion: infra.contrib.fluxcd.io/v1alpha2
+      kind: Terraform
+      name: authentik
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/flux-system/tofu-controller/terraform
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 10m
+  wait: true
 

--- a/kubernetes/apps/flux-system/tofu-controller/terraform/authentik.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/terraform/authentik.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/flux-iac/tofu-controller/main/docs/schemas/infra.contrib.fluxcd.io/terraform_v1alpha2.json
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: authentik
+spec:
+  interval: 1h
+  approvePlan: auto
+  path: ./terraform/authentik
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  varsFrom:
+    - kind: Secret
+      name: opentofu-secret

--- a/kubernetes/apps/flux-system/tofu-controller/terraform/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/terraform/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opentofu
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: opentofu-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        OP_CONNECT_HOST: http://onepassword-connect.external-secrets.svc.cluster.local:8080
+        OP_CONNECT_TOKEN: "{{ .OP_CONNECT_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: opentofu

--- a/kubernetes/apps/flux-system/tofu-controller/terraform/kustomization.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/terraform/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+resources:
+  - ./externalsecret.yaml
+  - ./authentik.yaml

--- a/terraform/authentik/.terraform.lock.hcl
+++ b/terraform/authentik/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/1password/onepassword" {
+  version     = "3.3.1"
+  constraints = "~> 3.3"
+  hashes = [
+    "h1:35PCpSNLVubReT1imwfC+FpIP5gQWx+rvG4njkXkZKM=",
+    "zh:02d93a7f520ec69ad8944a68dcbf512e2f9920a6696628b8d05e6ad408309f35",
+    "zh:0f91a902da84470af95f0da4dc21127b84e23c856a431ff9ecfe45d9c6775ef0",
+    "zh:161bc55c466214a5d425ba85753d74ed5078212db965f726e6650d2e1524d633",
+    "zh:3de4a9f212e1046016a3ace8816e2cb15cfb7b9579161e468a08b9034d6a5f51",
+    "zh:730105346065ea3d2bd6acc6f5fe36f7b8a2b54c513d20a46bcd51d656e82bb4",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:c29f6025d099bc8f1f96e7bb4cd66c5d07209b4141d2fd7720228cf20c9c8efd",
+    "zh:d8ea431d396986ca6baf033fa9aaccb73d6a9f9b7d42bea7af8dc73b9ef20297",
+  ]
+}
+
+provider "registry.opentofu.org/goauthentik/authentik" {
+  version     = "2026.2.0"
+  constraints = "~> 2026.0"
+  hashes = [
+    "h1:pum2uBRNDUjPeP9aYszm+6GU+K7tZIpbbLrsN39l8iw=",
+    "zh:00c44e8ee842e75de9cc4fd6193b10258d1dc840e5be4aaaf118ffc180dceee0",
+    "zh:13057f08bce3b63613e1be3997dd454ff9568c569dd983987b1550280fbe3d01",
+    "zh:410a1ff2ae4647cc0ab37894f81e4d474b588a0a7f005d05d55e8c3a40978dd2",
+    "zh:43830834d12b3c0eeabe397842f82ca3a6b58a5bc8dd837d55b821419b55ed61",
+    "zh:56eaedd196ed7c4003cee0434b891b38242b4fde2031978d0ddcfdf6e16ee5ad",
+    "zh:5b3c10bb63c3c215ed9e0918e5808b240e3f2ee8248d10cd4d824a4998a213c5",
+    "zh:99c14891bcb92a6b21ef4c0e60f6c0df23e3452808f3eefd67cde78d132c80d9",
+    "zh:9a32cdda9f939f8484e27d4200d004c44f016fe97579a111201083f4beea78e8",
+    "zh:ae5086816144f68de9a0002e7696321169a71473f9d161793f4ae996388f56de",
+    "zh:bd09409dd34608a4ef3ea80cfc5e397268e7872f2e84c1ccdc9b5698e36ddad5",
+    "zh:be7af8b9eb61b0eb5053f14360e5a68caeb32c115efe8e1b583f2e7c91352a2a",
+    "zh:e11726812a1b2caf6b6784a3d074d1f50e3d406e9629c02096a001e5a5979331",
+    "zh:e39183d10d8158ccab51208f4f727c7419b1b1e596f4feb23dc42aebb36d01e3",
+  ]
+}

--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -12,8 +12,8 @@ resource "authentik_group" "forgejo_admins" {
 
 resource "authentik_provider_oauth2" "forgejo" {
   name                       = "Forgejo"
-  client_id                  = local.forgejo_fields["AUTHENTIK_CLIENT_ID"]
-  client_secret              = local.forgejo_fields["AUTHENTIK_CLIENT_SECRET"]
+  client_id                  = local.forgejo_fields["AUTHENTIK_CLIENT_ID"].value
+  client_secret              = local.forgejo_fields["AUTHENTIK_CLIENT_SECRET"].value
   client_type                = "confidential"
   authorization_flow         = data.authentik_flow.authorization.id
   invalidation_flow          = data.authentik_flow.invalidation.id

--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -1,0 +1,55 @@
+locals {
+  forgejo_url = "https://forgejo.${var.CLUSTER_DOMAIN}"
+}
+
+resource "authentik_group" "forgejo_users" {
+  name = "forgejo-users"
+}
+
+resource "authentik_group" "forgejo_admins" {
+  name = "forgejo-admins"
+}
+
+resource "authentik_provider_oauth2" "forgejo" {
+  name                       = "Forgejo"
+  client_id                  = local.forgejo_fields["AUTHENTIK_CLIENT_ID"]
+  client_secret              = local.forgejo_fields["AUTHENTIK_CLIENT_SECRET"]
+  client_type                = "confidential"
+  authorization_flow         = data.authentik_flow.authorization.id
+  invalidation_flow          = data.authentik_flow.invalidation.id
+  signing_key                = data.authentik_certificate_key_pair.generated.id
+  include_claims_in_id_token = true
+  access_token_validity      = "hours=4"
+
+  allowed_redirect_uris = [
+    {
+      matching_mode = "strict"
+      url           = "${local.forgejo_url}/user/oauth2/authentik/callback"
+    },
+  ]
+
+  property_mappings = concat(
+    data.authentik_property_mapping_provider_scope.default.ids,
+    [authentik_property_mapping_provider_scope.groups.id],
+  )
+}
+
+resource "authentik_application" "forgejo" {
+  name               = "Forgejo"
+  slug               = "forgejo"
+  protocol_provider  = authentik_provider_oauth2.forgejo.id
+  meta_launch_url    = local.forgejo_url
+  policy_engine_mode = "all"
+}
+
+resource "authentik_policy_binding" "forgejo_users_access" {
+  target = authentik_application.forgejo.uuid
+  group  = authentik_group.forgejo_users.id
+  order  = 0
+}
+
+resource "authentik_policy_binding" "forgejo_admins_access" {
+  target = authentik_application.forgejo.uuid
+  group  = authentik_group.forgejo_admins.id
+  order  = 1
+}

--- a/terraform/authentik/locals.tf
+++ b/terraform/authentik/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  authentik_fields = data.onepassword_item.this["authentik"].section_map["terraform"].field_map
+  forgejo_fields   = data.onepassword_item.this["forgejo"].section_map["terraform"].field_map
+}

--- a/terraform/authentik/main.tf
+++ b/terraform/authentik/main.tf
@@ -21,47 +21,19 @@ data "onepassword_vault" "this" {
   name = var.OP_VAULT_NAME
 }
 
-data "onepassword_item" "authentik" {
-  vault = data.onepassword_vault.this.uuid
-  title = "authentik"
-}
+data "onepassword_item" "this" {
+  for_each = toset(["authentik", "forgejo"])
 
-data "onepassword_item" "forgejo" {
   vault = data.onepassword_vault.this.uuid
-  title = "forgejo"
+  title = each.key
 }
 
 locals {
-  authentik_fields = merge(
-    {
-      username = data.onepassword_item.authentik.username
-      password = data.onepassword_item.authentik.password
-    },
-    try(merge([
-      for section in data.onepassword_item.authentik.section : merge([
-        for field in section.field : {
-          (field.label) = field.value
-        }
-      ]...)
-    ]...), {})
-  )
-
-  forgejo_fields = merge(
-    {
-      username = data.onepassword_item.forgejo.username
-      password = data.onepassword_item.forgejo.password
-    },
-    try(merge([
-      for section in data.onepassword_item.forgejo.section : merge([
-        for field in section.field : {
-          (field.label) = field.value
-        }
-      ]...)
-    ]...), {})
-  )
+  authentik_fields = data.onepassword_item.this["authentik"].section_map["terraform"].field_map
+  forgejo_fields   = data.onepassword_item.this["forgejo"].section_map["terraform"].field_map
 }
 
 provider "authentik" {
   url   = var.AUTHENTIK_URL
-  token = local.authentik_fields["OPENTOFU_TOKEN"]
+  token = local.authentik_fields["OPENTOFU_TOKEN"].value
 }

--- a/terraform/authentik/main.tf
+++ b/terraform/authentik/main.tf
@@ -1,0 +1,67 @@
+terraform {
+  required_providers {
+    authentik = {
+      source  = "goauthentik/authentik"
+      version = "~> 2026.0"
+    }
+
+    onepassword = {
+      source  = "1Password/onepassword"
+      version = "~> 3.3"
+    }
+  }
+}
+
+provider "onepassword" {
+  connect_url   = var.OP_CONNECT_HOST
+  connect_token = var.OP_CONNECT_TOKEN
+}
+
+data "onepassword_vault" "this" {
+  name = var.OP_VAULT_NAME
+}
+
+data "onepassword_item" "authentik" {
+  vault = data.onepassword_vault.this.uuid
+  title = "authentik"
+}
+
+data "onepassword_item" "forgejo" {
+  vault = data.onepassword_vault.this.uuid
+  title = "forgejo"
+}
+
+locals {
+  authentik_fields = merge(
+    {
+      username = data.onepassword_item.authentik.username
+      password = data.onepassword_item.authentik.password
+    },
+    try(merge([
+      for section in data.onepassword_item.authentik.section : merge([
+        for field in section.field : {
+          (field.label) = field.value
+        }
+      ]...)
+    ]...), {})
+  )
+
+  forgejo_fields = merge(
+    {
+      username = data.onepassword_item.forgejo.username
+      password = data.onepassword_item.forgejo.password
+    },
+    try(merge([
+      for section in data.onepassword_item.forgejo.section : merge([
+        for field in section.field : {
+          (field.label) = field.value
+        }
+      ]...)
+    ]...), {})
+  )
+}
+
+provider "authentik" {
+  url   = var.AUTHENTIK_URL
+  token = local.authentik_fields["OPENTOFU_TOKEN"]
+}

--- a/terraform/authentik/main.tf
+++ b/terraform/authentik/main.tf
@@ -28,11 +28,6 @@ data "onepassword_item" "this" {
   title = each.key
 }
 
-locals {
-  authentik_fields = data.onepassword_item.this["authentik"].section_map["terraform"].field_map
-  forgejo_fields   = data.onepassword_item.this["forgejo"].section_map["terraform"].field_map
-}
-
 provider "authentik" {
   url   = var.AUTHENTIK_URL
   token = local.authentik_fields["OPENTOFU_TOKEN"].value

--- a/terraform/authentik/scopes.tf
+++ b/terraform/authentik/scopes.tf
@@ -1,0 +1,29 @@
+data "authentik_flow" "authorization" {
+  slug = "default-provider-authorization-implicit-consent"
+}
+
+data "authentik_flow" "invalidation" {
+  slug = "default-provider-invalidation-flow"
+}
+
+data "authentik_certificate_key_pair" "generated" {
+  name = "authentik Self-signed Certificate"
+}
+
+data "authentik_property_mapping_provider_scope" "default" {
+  managed_list = [
+    "goauthentik.io/providers/oauth2/scope-openid",
+    "goauthentik.io/providers/oauth2/scope-email",
+    "goauthentik.io/providers/oauth2/scope-profile",
+  ]
+}
+
+resource "authentik_property_mapping_provider_scope" "groups" {
+  name       = "Forgejo groups"
+  scope_name = "groups"
+  expression = <<-EOF
+    return {
+      "groups": [group.name for group in request.user.ak_groups.all()],
+    }
+  EOF
+}

--- a/terraform/authentik/variables.tf
+++ b/terraform/authentik/variables.tf
@@ -1,0 +1,28 @@
+variable "OP_CONNECT_HOST" {
+  type        = string
+  description = "1Password Connect API URL."
+}
+
+variable "OP_CONNECT_TOKEN" {
+  type        = string
+  description = "1Password Connect API token."
+  sensitive   = true
+}
+
+variable "OP_VAULT_NAME" {
+  type        = string
+  description = "1Password vault containing Terraform-managed application secrets."
+  default     = "Homelab-Kubernetes"
+}
+
+variable "CLUSTER_DOMAIN" {
+  type        = string
+  description = "Primary cluster DNS domain."
+  default     = "toskbot.xyz"
+}
+
+variable "AUTHENTIK_URL" {
+  type        = string
+  description = "Base URL for Authentik."
+  default     = "https://auth.toskbot.xyz"
+}


### PR DESCRIPTION
## Summary
- add tofu-controller resources for the Authentik OpenTofu stack
- manage Forgejo OAuth2 provider, application, groups, and scope mappings in Authentik
- wire Forgejo to Authentik OIDC with auto-registration

## Verification
- tofu fmt -check -diff terraform/authentik
- tofu -chdir=terraform/authentik validate

<!-- branch-stack-start -->

<!-- branch-stack-end -->
