### PR TITLE
deps(tofu-controller): upgrade to 0.16.3

### DIFF
--- a/kubernetes/apps/flux-system/tofu-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.16.0-rc.5
+    tag: 0.16.3
   url: oci://ghcr.io/flux-iac/charts/tofu-controller
 ---
 # yaml-language-server: $schema=https://kube-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
@@ -28,7 +28,7 @@ spec:
     runner:
       image:
         repository: ghcr.io/flux-iac/tf-runner
-        tag: 0.16.0-rc.5
+        tag: v0.16.3
     metrics:
       enabled: true
       serviceMonitor:


### PR DESCRIPTION
## Summary
- upgrade tofu-controller chart from 0.16.0-rc.5 to 0.16.3
- update tf-runner image tag to v0.16.3

## Verification
- helm show chart oci://ghcr.io/flux-iac/charts/tofu-controller --version 0.16.3
- helm template confirmed rendered chart uses source.toolkit.fluxcd.io/v1 and v0.16.3 images

<!-- branch-stack-start -->

<!-- branch-stack-end -->
