### PR TITLE
deps(tofu-controller): use home-operations runner

### DIFF
--- a/kubernetes/apps/flux-system/tofu-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/app/helmrelease.yaml
@@ -27,8 +27,8 @@ spec:
   values:
     runner:
       image:
-        repository: ghcr.io/flux-iac/tf-runner
-        tag: v0.16.3
+        repository: ghcr.io/home-operations/opentofu-runner
+        tag: 1.12.0
     metrics:
       enabled: true
       serviceMonitor:


### PR DESCRIPTION
## Summary
- point tofu-controller runner pods at ghcr.io/home-operations/opentofu-runner:1.12.0
- use a maintained runner image with glibc compatibility for dynamically linked providers like 1Password

## Verification
- docker run verified ghcr.io/home-operations/opentofu-runner:1.12.0 includes tf-runner, OpenTofu, gcompat, and libc6-compat
- docker run verified the 1Password provider binary can start in that image
- helm template confirmed RUNNER_POD_IMAGE=ghcr.io/home-operations/opentofu-runner:1.12.0 and no source.toolkit.fluxcd.io/v1beta2 references

<!-- branch-stack-start -->

<!-- branch-stack-end -->
