### PR TITLE
fix(authentik): use in-cluster terraform endpoint

### DIFF
--- a/kubernetes/apps/flux-system/tofu-controller/terraform/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/terraform/externalsecret.yaml
@@ -16,6 +16,7 @@ spec:
       data:
         OP_CONNECT_HOST: http://onepassword-connect.external-secrets.svc.cluster.local:8080
         OP_CONNECT_TOKEN: "{{ .OP_CONNECT_TOKEN }}"
+        AUTHENTIK_URL: http://authentik-server.security.svc.cluster.local
   dataFrom:
     - extract:
         key: opentofu

--- a/terraform/authentik/variables.tf
+++ b/terraform/authentik/variables.tf
@@ -24,5 +24,4 @@ variable "CLUSTER_DOMAIN" {
 variable "AUTHENTIK_URL" {
   type        = string
   description = "Base URL for Authentik."
-  default     = "https://auth.toskbot.xyz"
 }


### PR DESCRIPTION
## Summary
- set AUTHENTIK_URL for the tofu-controller Terraform secret
- use the in-cluster authentik service DNS name instead of the external hostname

## Verification
- yq verified AUTHENTIK_URL in the ExternalSecret template
- kubectl kustomize kubernetes/apps/flux-system/tofu-controller/terraform rendered the expected value

<!-- branch-stack-start -->

<!-- branch-stack-end -->
